### PR TITLE
Update jamovibastats.a.yaml

### DIFF
--- a/jamovi/jamovibastats.a.yaml
+++ b/jamovi/jamovibastats.a.yaml
@@ -4,7 +4,7 @@ title: Bland-Altman raw statistics for Jamovi
 menuGroup: blandr
 menuSubgroup: Raw Output
 version: '1.0.0'
-jas: '1.1'
+jas: '1.2'
 
 options:
     - name: data
@@ -16,9 +16,8 @@ options:
       suggested:
         - continuous
       permitted:
-        - continuous
-        - nominal
-        - ordinal
+        - numeric
+        - factor
 
     - name: method2
       title: Method 2
@@ -26,8 +25,7 @@ options:
       suggested:
         - continuous
       permitted:
-        - continuous
-        - nominal
-        - ordinal
+        - numeric
+        - factor
 
 ...


### PR DESCRIPTION
Compatibility fix for jamovi 0.9.1+, see https://dev.jamovi.org/