### PR TITLE
Update jamovibaplotqq.u.yaml

### DIFF
--- a/jamovi/jamovibaplotqq.u.yaml
+++ b/jamovi/jamovibaplotqq.u.yaml
@@ -6,9 +6,8 @@ compilerMode: tame
 children:
   - type: VariableSupplier
     permitted:
-      - continuous
-      - nominal
-      - ordinal
+        - numeric
+        - factor
     persistentItems: false
     stretchFactor: 1
     children:


### PR DESCRIPTION
Compatibility fix for jamovi 0.9.1+, see https://dev.jamovi.org/