### PR TITLE
Update jamovibaplothistogram.u.yaml

### DIFF
--- a/jamovi/jamovibaplothistogram.u.yaml
+++ b/jamovi/jamovibaplothistogram.u.yaml
@@ -6,9 +6,8 @@ compilerMode: tame
 children:
   - type: VariableSupplier
     permitted:
-      - continuous
-      - nominal
-      - ordinal
+        - numeric
+        - factor
     persistentItems: false
     stretchFactor: 1
     children:


### PR DESCRIPTION
Compatibility fix for jamovi 0.9.1+, see https://dev.jamovi.org/